### PR TITLE
[FIX] account.journal.dashboard.kanban: Replace amount.total by sum residual field 

### DIFF
--- a/addons/account/models/account_journal_dashboard.py
+++ b/addons/account/models/account_journal_dashboard.py
@@ -224,7 +224,7 @@ class account_journal(models.Model):
         data as its first element, and the arguments dictionary to use to run
         it as its second.
         """
-        return ("""SELECT state, amount_total, currency_id AS currency, type
+        return ("""SELECT state, residual, currency_id AS currency, type
                   FROM account_invoice
                   WHERE journal_id = %(journal_id)s AND state = 'open';""", {'journal_id':self.id})
 
@@ -234,7 +234,7 @@ class account_journal(models.Model):
         gather the bills in draft state data, and the arguments
         dictionary to use to run it as its second.
         """
-        return ("""SELECT state, amount_total, currency_id AS currency, type
+        return ("""SELECT state, residual, currency_id AS currency, type
                   FROM account_invoice
                   WHERE journal_id = %(journal_id)s AND state = 'draft';""", {'journal_id':self.id})
 
@@ -249,7 +249,7 @@ class account_journal(models.Model):
             rslt_count += 1
 
             type_factor = result.get('type') in ('in_refund', 'out_refund') and -1 or 1
-            rslt_sum += type_factor * cur.compute(result.get('amount_total'), target_currency)
+            rslt_sum += type_factor * cur.compute(result.get('residual'), target_currency)
         return (rslt_count, rslt_sum)
 
     @api.multi


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
The accounting control panel is to see in a quick and graphic way the accounting data and the situation of the expenses and income of the company

Current behavior before PR:
In the account control panel, the data of the total balance of the invoices receivable or payable is total amount.

Desired behavior after PR is merged:

The total data of the open invoices should be obtained from the residual field

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr